### PR TITLE
4: Support cron deployment

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,5 +4,6 @@ good-names=
 
 [MESSAGES CONTROL]
 disable=
+  no-self-use,
   too-few-public-methods,
   too-many-instance-attributes

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ $ sudo -H pip3 install --upgrade .
 
 # Usage
 ```
-usage: pifan [-h] [--interval SEC] [--idealtemp DEG_C] [--maxtemp DEG_C]
-             [--easing TYPE] [--sample-size N] [--dry-run]
+usage: pifan [-h] [--one | --interval SEC] [--idealtemp DEG_C]
+             [--maxtemp DEG_C] [--easing TYPE] [--sample-size N] [--dry-run]
              HOST USERNAME PASSWORD
 
 Dell PowerEdge fan speed controller for Raspberry Pi.
@@ -60,7 +60,8 @@ positional arguments:
 
 optional arguments:
   -h, --help         show this help message and exit
-  --interval SEC     Delay between polls
+  --one              Poll once and exit
+  --interval SEC     Delay between polls (default: 10)
   --idealtemp DEG_C  Ideal temperature (default: 40)
   --maxtemp DEG_C    Max allowable temperature (default: 75)
   --easing TYPE      Fan speed easing type: linear | parabolic (default: parabolic)
@@ -87,7 +88,12 @@ allowed.
 
 # Best Practices
 * Run PiFan on a physical Pi.
+* Deploy PiFan as a [cron job](#cron-job-deployment).
 * Power the Pi with a UPS.
+
+# Cron Job Deployment
+Maintain multiple servers by deploying a cron job for each server.  Be sure to
+use the `--one` option.
 
 # Setup Development Environment
 Most of the Python operations are wrapped in `pipenv` so as not to step all

--- a/bin/pifan
+++ b/bin/pifan
@@ -4,7 +4,8 @@ Pi Fan
 """
 
 import argparse
-from mylib import PiFanController, IpmiCpu, IpmiFan
+from datetime import timedelta
+from mylib import PiFanController, Monitor, IpmiCpu, IpmiFan
 
 
 def parse_args():
@@ -16,8 +17,14 @@ def parse_args():
         description='Dell PowerEdge fan speed controller for Raspberry Pi.',
         epilog=""
     )
-    parser.add_argument('--interval', type=int, metavar='SEC', default=10,
-                        help='Delay between polls')
+
+    run_mode_group = parser.add_mutually_exclusive_group()
+    run_mode_group.add_argument('--one', default=False, action='store_true',
+                                help='Poll once and exit')
+    run_mode_group.add_argument('--interval', type=int, metavar='SEC',
+                                default=10,
+                                help='Delay between polls (default: 10)')
+
     parser.add_argument('--idealtemp', type=float, metavar='DEG_C', default=40,
                         help='Ideal temperature (default: 40)')
     parser.add_argument('--maxtemp', type=float, metavar='DEG_C', default=75,
@@ -29,8 +36,7 @@ def parse_args():
     parser.add_argument('--sample-size', type=int, metavar='N', default=3,
                         help='Sample size of CPU temp average aggregation '
                              '(default: 3)')
-    parser.add_argument('--dry-run', const=True, default=False,
-                        action='store_const',
+    parser.add_argument('--dry-run', default=False, action='store_true',
                         help='Dry run: don\'t change server settings')
     parser.add_argument('host', metavar='HOST', help='Target host')
     parser.add_argument('username', metavar='USERNAME', help='Username')
@@ -50,14 +56,25 @@ def main():
     ipmi_cpu = IpmiCpu(args.host, args.username, args.password)
     ipmi_cpu.discover_sensors()
 
-    controller = PiFanController(ipmi_fan, ipmi_cpu)
-    controller.interval = args.interval
+    controller = PiFanController(args.host, ipmi_fan, ipmi_cpu)
     controller.ideal_temp = args.idealtemp
     controller.max_temp = args.maxtemp
     controller.easing = args.easing
     controller.dry_run = args.dry_run
     controller.sample_size = args.sample_size
-    controller.monitor()
+
+    print()
+
+    if args.one:
+        # Single poll.
+        state = controller.load_state()
+        controller.poll(state)
+    else:
+        # Endless polling.
+        state = controller.load_state()
+        interval = timedelta(seconds=args.interval)
+        monitor = Monitor(controller, state, interval)
+        monitor.launch()
 
 
 if __name__ == '__main__':

--- a/bin/pifan
+++ b/bin/pifan
@@ -52,9 +52,7 @@ def main():
     args = parse_args()
 
     ipmi_fan = IpmiFan(args.host, args.username, args.password)
-    ipmi_fan.discover_sensors()
     ipmi_cpu = IpmiCpu(args.host, args.username, args.password)
-    ipmi_cpu.discover_sensors()
 
     controller = PiFanController(args.host, ipmi_fan, ipmi_cpu)
     controller.ideal_temp = args.idealtemp
@@ -62,8 +60,6 @@ def main():
     controller.easing = args.easing
     controller.dry_run = args.dry_run
     controller.sample_size = args.sample_size
-
-    print()
 
     if args.one:
         # Single poll.
@@ -73,8 +69,8 @@ def main():
         # Endless polling.
         state = controller.load_state()
         interval = timedelta(seconds=args.interval)
-        monitor = Monitor(controller, state, interval)
-        monitor.launch()
+        monitor = Monitor(controller, interval)
+        monitor.launch(state)
 
 
 if __name__ == '__main__':

--- a/src/mylib/__init__.py
+++ b/src/mylib/__init__.py
@@ -3,4 +3,5 @@ PiFan local modules.
 """
 from .ipmi_cpu import IpmiCpu
 from .ipmi_fan import IpmiFan
+from .monitor import Monitor
 from .pi_fan_controller import PiFanController

--- a/src/mylib/__init__.py
+++ b/src/mylib/__init__.py
@@ -1,6 +1,7 @@
 """
 PiFan local modules.
 """
+from .controller_state import ControllerState
 from .ipmi_cpu import IpmiCpu
 from .ipmi_fan import IpmiFan
 from .monitor import Monitor

--- a/src/mylib/controller_state.py
+++ b/src/mylib/controller_state.py
@@ -1,0 +1,75 @@
+"""
+Runtime state of PiFanController.
+"""
+from datetime import datetime, timedelta
+from functools import reduce
+import pickle
+from typing import Dict, List
+from .cpu_sensor import CpuSensor
+from .fan_sensor import FanSensor
+
+
+class ControllerState:
+    """
+    Runtime state of PiFanController.
+    """
+    sample_size: int
+
+    samples: List[float]
+
+    cpu_map: Dict[str, CpuSensor]
+
+    fan_map: Dict[str, FanSensor]
+
+    # Epoch seconds.
+    last_sample_time: float
+
+    def __init__(self):
+        self.sample_size = 3
+        self.samples = []
+        self.last_sample_time = None
+        self.cpu_map = None
+        self.fan_map = None
+
+    def add_aggregate_temp(self, value: float) -> float:
+        """
+        Add a CPU temp value to aggregate average.
+        Return new average.
+        """
+        # Check if aggregate samples are too old.
+        if self.last_sample_time is not None:
+            last_sample_time2 = datetime.fromtimestamp(self.last_sample_time)
+            now = datetime.now()
+            threshold_time = now - timedelta(hours=1)
+            if last_sample_time2 < threshold_time:
+                # Too old, clear samples.
+                self.samples = []
+
+        self.samples.append(value)
+        self.samples = self.samples[-self.sample_size:]
+        agg_value = reduce(
+            lambda a, b: a + b,
+            self.samples
+        ) / len(self.samples)
+        self.last_sample_time = datetime.now().timestamp()
+        return agg_value
+
+    def set_sample_size(self, sample_size: int) -> None:
+        """
+        Set sample size.
+        """
+        self.sample_size = sample_size
+        self.samples = self.samples[-sample_size:]
+
+    def restore(self, serialized: bytes) -> None:
+        """
+        Restore state from serialized data previously created by dump().
+        """
+        loaded_state = pickle.loads(serialized)
+        self.__dict__.update(loaded_state.__dict__)
+
+    def dump(self) -> bytes:
+        """
+        Serialize state.
+        """
+        return pickle.dumps(self)

--- a/src/mylib/cpu_sensor.py
+++ b/src/mylib/cpu_sensor.py
@@ -1,0 +1,23 @@
+"""
+CPU sensor state.
+"""
+
+
+class CpuSensor:
+    """
+    CPU sensor state.
+    """
+    name: str
+
+    id: int
+
+    temp: float
+
+    def __init__(self) -> None:
+        self.name = ''
+        self.id = 0
+        self.temp = 0.0
+
+    def __str__(self) -> str:
+        return(f'CpuSensor: name={self.name}, id={self.id:#x}, '
+               f'temp={self.temp}C')

--- a/src/mylib/fan_sensor.py
+++ b/src/mylib/fan_sensor.py
@@ -1,0 +1,36 @@
+"""
+Fan sensor state.
+"""
+
+
+class FanSensor:
+    """
+    Fan sensor state.
+    """
+    name: str
+
+    id: int
+
+    rpm: int
+
+    max: int
+
+    def __init__(self) -> None:
+        self.name = ''
+        self.id = 0
+        self.rpm = 0
+        self.max = 0
+
+    def __str__(self) -> str:
+        return(f'FanSensor: name={self.name}, id={self.id:#x}, '
+               f'rpm={self.rpm}, max={self.max}, '
+               f'percent={self.percent():0.1f}%')
+
+    def percent(self) -> float:
+        """
+        Compute fan percentage.
+        """
+        if self.max == 0:
+            return float('nan')
+
+        return float(self.rpm) / float(self.max) * 100.0

--- a/src/mylib/ipmi_cpu.py
+++ b/src/mylib/ipmi_cpu.py
@@ -4,45 +4,24 @@ IPMI control of CPU temperatures.
 
 import re
 from typing import Dict
+from .controller_state import ControllerState
+from .cpu_sensor import CpuSensor
 from .ipmitool import Ipmitool
 from .util import parse_hex
-
-
-class CpuSensor:
-    """
-    CPU sensor state.
-    """
-    name: str
-
-    id: int
-
-    temp: float
-
-    def __init__(self) -> None:
-        self.name = ''
-        self.id = 0
-        self.temp = 0.0
-
-    def __str__(self) -> str:
-        return(f'CpuSensor: name={self.name}, id={self.id:#x}, '
-               f'temp={self.temp}C')
 
 
 class IpmiCpu:
     """
     IPMI control of CPU temperatures.
     """
-    cpu_map: Dict[str, CpuSensor]
-
     ipmitool: Ipmitool
 
     pat_integer = re.compile(r'^(\d+)')
 
     def __init__(self, host: str, username: str, password: str) -> None:
-        self.cpu_map = {}
         self.ipmitool = Ipmitool(host, username, password)
 
-    def discover_sensors(self) -> None:
+    def discover_sensors(self, state: ControllerState) -> None:
         """
         Query IPMI for list of CPUs.
         Must call this method first before using this class.
@@ -70,13 +49,13 @@ class IpmiCpu:
             key = f'{name} ({sensor.id:#x})'
             cpu_map[key] = sensor
 
-        self.cpu_map = cpu_map
-        self.dump_sensors()
+        state.cpu_map = cpu_map
+        self.dump_sensors(state)
 
-    def read_sensors(self) -> None:
+    def read_sensors(self, state: ControllerState) -> None:
         """
         Read current sensor values.
-        Store values in self.cpu_map.
+        Store values in state.
         """
         rows = self.ipmitool.sdr_type('temperature')
 
@@ -85,33 +64,33 @@ class IpmiCpu:
                 continue
 
             key = f'{row[0]} ({parse_hex(row[1]):#x})'
-            if key in self.cpu_map:
-                sensor = self.cpu_map[key]
+            if key in state.cpu_map:
+                sensor = state.cpu_map[key]
 
                 # CPU temperature
                 match_integer = self.pat_integer.match(row[4])
                 if match_integer is not None:
                     sensor.temp = int(match_integer.groups()[0])
 
-        self.dump_sensors()
+        self.dump_sensors(state)
 
-    def dump_sensors(self) -> None:
+    def dump_sensors(self, state: ControllerState) -> None:
         """
         Dump sensors to console.
         """
-        names = self.cpu_map.keys()
+        names = state.cpu_map.keys()
         for name in sorted(names):
-            cpu = self.cpu_map[name]
+            cpu = state.cpu_map[name]
             print(cpu)
 
-    def get_max_cpu_temp(self) -> float:
+    def get_max_cpu_temp(self, state: ControllerState) -> float:
         """
         Get maximum of CPU temps.
         """
         temp: float = 0.0
 
-        for key in self.cpu_map:
-            sensor = self.cpu_map[key]
+        for key in state.cpu_map:
+            sensor = state.cpu_map[key]
             temp = max(temp, sensor.temp)
 
         return temp

--- a/src/mylib/monitor.py
+++ b/src/mylib/monitor.py
@@ -1,0 +1,42 @@
+"""
+Continuously monitor by polling at an interval.
+"""
+from datetime import datetime, timedelta
+import time
+from .pi_fan_controller import ControllerState, PiFanController
+
+
+class Monitor:
+    """
+    Continuously monitor by polling at an interval.
+    """
+    controller: PiFanController
+
+    state: ControllerState
+
+    interval: timedelta
+
+    def __init__(self, controller: PiFanController, state: ControllerState,
+                 interval: timedelta):
+        self.controller = controller
+        self.state = state
+        self.interval = interval
+
+    def launch(self) -> None:
+        """
+        Continuously poll fan and CPU sensors and adjust fan speed according
+        to easing algorithm.
+        """
+        # Prepare state by loading from file, if exists.
+        state = self.controller.load_state()
+
+        while True:
+            poll_start_time = datetime.now()
+            self.controller.poll(state)
+
+            # Wait for next polling interval.
+            poll_end_time = datetime.now()
+            next_poll_time = poll_start_time + self.interval
+            delay = (next_poll_time - poll_end_time).total_seconds()
+            if delay > 0:
+                time.sleep(delay)

--- a/src/mylib/util.py
+++ b/src/mylib/util.py
@@ -7,6 +7,10 @@ from typing import List
 import unicodedata
 
 
+RE_SLUG1 = re.compile(r'[^.\w\s-]')
+RE_SLUG2 = re.compile(r'[-\s]+')
+
+
 def parse_pdv(text: str) -> List[List[str]]:
     """
     Parse pipe delimited values.
@@ -37,8 +41,6 @@ def parse_hex(text: str) -> int:
         text = '0x' + text
     return int(text, 0)
 
-re_slug1 = re.compile(r'[^.\w\s-]')
-re_slug2 = re.compile(r'[-\s]+')
 
 def make_slug(value: str) -> str:
     """
@@ -48,5 +50,5 @@ def make_slug(value: str) -> str:
         .encode('ascii', 'ignore')\
         .decode('ascii')\
         .lower()
-    value = re_slug1.sub('', value)
-    return re_slug2.sub('-', value).strip('-_')
+    value = RE_SLUG1.sub('', value)
+    return RE_SLUG2.sub('-', value).strip('-_')

--- a/src/mylib/util.py
+++ b/src/mylib/util.py
@@ -2,7 +2,9 @@
 General utilities.
 """
 
+import re
 from typing import List
+import unicodedata
 
 
 def parse_pdv(text: str) -> List[List[str]]:
@@ -34,3 +36,17 @@ def parse_hex(text: str) -> int:
     if not text.startswith('0x'):
         text = '0x' + text
     return int(text, 0)
+
+re_slug1 = re.compile(r'[^.\w\s-]')
+re_slug2 = re.compile(r'[-\s]+')
+
+def make_slug(value: str) -> str:
+    """
+    Normalize a string for use as a slug, such as for filename.
+    """
+    value = unicodedata.normalize('NFKD', value)\
+        .encode('ascii', 'ignore')\
+        .decode('ascii')\
+        .lower()
+    value = re_slug1.sub('', value)
+    return re_slug2.sub('-', value).strip('-_')


### PR DESCRIPTION
Implement `--one` option to run a single poll.
Runtime state is preserved as a file in `/tmp/pifan-<host>.dat` so that recurring cron jobs will remember sensor state.

Closes #4